### PR TITLE
api changes (breaking changes):

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,6 @@ services:
             - 9020:9020
 
     redis:
-        image: redis:2.8.21
+        image: redis:3.2.4
 
 

--- a/shepherd/dockercontroller.py
+++ b/shepherd/dockercontroller.py
@@ -189,15 +189,6 @@ class DockerController(object):
 
         return props
 
-    def _get_host_port(self, info, port, default_host):
-        info = info['NetworkSettings']['Ports'][str(port) + '/tcp']
-        info = info[0]
-        host = info['HostIp']
-        if host == '0.0.0.0' and default_host:
-            host = default_host
-
-        return host + ':' + info['HostPort']
-
     def _get_port(self, info, port):
         info = info['NetworkSettings']['Ports'][str(port) + '/tcp']
         info = info[0]
@@ -206,9 +197,9 @@ class DockerController(object):
     def sid(self, id):
         return id[:12]
 
-    def timed_new_container(self, browser, env, host, reqid, audio=None):
+    def timed_new_container(self, browser, env, host, reqid, audio, opts):
         start = time.time()
-        info = self.new_container(browser, env, host, audio=audio)
+        info = self.new_container(browser, env, host, audio=audio, opts=opts)
         end = time.time()
         dur = end - start
 
@@ -222,7 +213,8 @@ class DockerController(object):
 
         return info
 
-    def new_container(self, browser_id, env=None, default_host=None, audio=None):
+    def new_container(self, browser_id, env=None, default_host=None, audio=None, opts=None):
+        #browser = self.browsers.get(browser_id)
         browser = self.get_browser_info(browser_id)
 
         # get default browser
@@ -240,7 +232,7 @@ class DockerController(object):
         print('Launching ' + image)
 
         try:
-            container = self.create_container(image, env)
+            container = self.create_container(image, env, opts)
 
             info, ip = self.get_ip(container)
 
@@ -252,7 +244,7 @@ class DockerController(object):
             result = {}
 
             for port_name in self.ports:
-                result[port_name + '_host'] = self._get_host_port(info, self.ports[port_name], default_host)
+                result[port_name + '_port'] = self._get_port(info, self.ports[port_name])
 
             result['id'] = short_id
             result['ip'] = ip
@@ -285,16 +277,18 @@ class DockerController(object):
                 time.sleep(0.2)
                 pass
 
-    def create_container(self, image, env):
+    def create_container(self, image, env, opts):
         if self.volume_source:
             volumes_from = [self.volume_source]
         else:
             volumes_from = None
 
+        network_name = opts.get('network_name') or self.network_name
+
         container = self.cli.containers.run(image=image,
                                               detach=True,
                                               ports=self.port_bindings,
-                                              network=self.network_name,
+                                              network=network_name,
                                               environment=env,
                                               labels={self.label_name: self.name},
                                               volumes_from=volumes_from,
@@ -523,6 +517,8 @@ class DockerController(object):
         url = container_data.get('url', 'about:blank')
         ts = container_data.get('request_ts')
 
+        opts = {'network_name': container_data.get('network_name', self.network_name)}
+
         env = {}
         env['URL'] = url
         env['TS'] = ts
@@ -532,14 +528,14 @@ class DockerController(object):
         vnc_pass = self._make_vnc_pass()
         env['VNC_PASS'] = vnc_pass
 
-        self._copy_env(env, 'PROXY_HOST')
+        self._copy_env(env, 'PROXY_HOST', container_data.get('proxy_host'))
         self._copy_env(env, 'PROXY_PORT')
         self._copy_env(env, 'PROXY_GET_CA')
         self._copy_env(env, 'SCREEN_WIDTH', width)
         self._copy_env(env, 'SCREEN_HEIGHT', height)
         self._copy_env(env, 'IDLE_TIMEOUT')
 
-        info = self.timed_new_container(browser, env, host, reqid, audio)
+        info = self.timed_new_container(browser, env, host, reqid, audio, opts=opts)
         info['queue'] = 0
         info['vnc_pass'] = vnc_pass
 
@@ -557,6 +553,23 @@ class DockerController(object):
 
         info['ttl'] = self.duration
         return info
+
+    def remove_browser(self, reqid):
+        short_id = self.redis.hget('req:' + reqid, 'id')
+
+        try:
+            container = self.cli.containers.get(short_id)
+        except Exception as e:
+            print('Container Not Found: ' + short_id)
+            return False
+
+        try:
+            container.remove(force=True)
+        except Exception as e:
+            print('Remove error: ' + str(e))
+            return False
+
+        return True
 
     def clone_browser(self, reqid, id_, name):
         short_id = self.redis.hget('req:' + reqid, 'id')

--- a/shepherd/main.py
+++ b/shepherd/main.py
@@ -38,10 +38,8 @@ class Main(object):
         if not reqid:
             reqid = self.dc.register_request(container_data)
 
-        container_data['reqid'] = reqid
-
         return {'STATIC_PREFIX': '/static',
-                'container_data': container_data,
+                'reqid': reqid,
                 'audio': os.environ.get('AUDIO_ALLOWED', '1'),
                }
 
@@ -82,6 +80,13 @@ class Main(object):
                 url += '?' + request.query_string
 
             return self.load_browser(browser, url)
+
+        @route('/attach/<reqid>')
+        @jinja2_view('browser_embed.html', template_lookup=['templates'])
+        def route_attach_view(reqid):
+            return {'reqid': reqid,
+                    'audio': os.environ.get('AUDIO_ALLOWED', '1')
+                   }
 
         @route('/request_browser/<browser>', method='POST')
         def request_browser(browser):
@@ -137,6 +142,16 @@ class Main(object):
 
             response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
             return resp
+
+        @route('/remove_browser')
+        def remove_browser():
+            reqid = request.query.get('reqid', '')
+
+            resp = self.dc.remove_browser(reqid)
+            if resp:
+                return {'success': 'deleted'}
+            else:
+                return {'error': 'not_deleted'}
 
         @route('/static/<filepath:path>')
         def server_static(filepath):

--- a/shepherd/static/audio.js
+++ b/shepherd/static/audio.js
@@ -15,12 +15,8 @@ var AUDIO_TYPES = [
 var WSAudio = function(browser_info, init_params) {
     init_params = init_params || {};
 
-    var audioCount = 0;
-
     var MAX_BUFFERS = 250;
     var MIN_START_BUFFERS = 10;
-
-    var MAX_ERRORS = 1;
 
     var minLatency = 0.2; // 200ms
     var maxLatency = 0.5  // 500ms
@@ -55,13 +51,14 @@ var WSAudio = function(browser_info, init_params) {
 
     this.get_ws_url = function(browser_info) {
         var ws_url = (window.location.protocol == "https:" ? "wss:" : "ws:");
+        ws_url += window.location.hostname;
+
+        var audio_port = browser_info.cmd_port;
 
         if (init_params.proxy_ws) {
-            var audio_port = browser_info.cmd_host.split(":")[1];
-            ws_url += window.location.host + "/" + init_params.proxy_ws + audio_port;
-            ws_url += "&count=" + audioCount++;
+            ws_url += "/" + init_params.proxy_ws + audio_port;
         } else {
-            ws_url += browser_info.cmd_host + "/audio_ws";
+            ws_url += ":" + audio_port + "/audio_ws";
         }
 
         return ws_url;
@@ -69,6 +66,10 @@ var WSAudio = function(browser_info, init_params) {
 
 
     this.start = function() {
+        if (this.audio) {
+           return true;
+        }
+
         this.audio_mime = this.get_audio_mime(browser_info);
         this.ws_url = this.get_ws_url(browser_info);
 
@@ -281,7 +282,7 @@ var WSAudio = function(browser_info, init_params) {
     }
 
     var ws_message = function(event) {
-        if (this.errCount < MAX_ERRORS) {
+        if (this.errCount == 0) {
             this.queue(event.data);
         }
     }

--- a/shepherd/templates/browser_embed.html
+++ b/shepherd/templates/browser_embed.html
@@ -13,7 +13,7 @@
 {% endif %}
 
 <script>
-window.reqid = "{{ container_data.reqid }}";
+window.reqid = "{{ reqid }}";
 
 $(function() {
     function on_countdown(seconds, countdown_text) {


### PR DESCRIPTION
- return 'vnc_port' and 'cmd_port' instead of 'cmd_host' and 'vnc_host', as host is determined client-side
- support /attach/ endpoint for attaching to existing browser by reqid
- allow specifiying custom network and custom proxy_host per browser request
- add /remove_browser endpoint
- audio fixes: change cmd_host->cmd_port usage
- audio: start audio on first click, prevent double init, cleanup